### PR TITLE
Fix variables names in blue_noise_optimize_fft.ipynb

### DIFF
--- a/blue_noise_optimize_fft.ipynb
+++ b/blue_noise_optimize_fft.ipynb
@@ -79,7 +79,7 @@
         "  uniformity_loss = spectrum_uniformity_loss(m, SIZE) * loss_component_1\n",
         "  return 0.01 * uniformity_loss + 2.2 * range_loss + 0.1 * spectral_loss\n",
         "\n",
-        "grad = jax.jit(jnp.real(jax.grad(loss)))\n",
+        "grad = jax.jit(jnp.real(jax.grad(full_loss)))\n",
         "loss = jax.jit(full_loss)\n"
       ],
       "execution_count": 0,
@@ -123,7 +123,7 @@
         "print(loss(noise_mat, 1.0, 0.0, 0.0), loss(noise_mat, 0.0, 1.0, 0.0), loss(noise_mat, 0.0, 1.0, 0.0), loss(noise_mat, 1.0, 1.0, 1.0))\n",
         "# fine tune the histogram\n",
         "for i in range(10):\n",
-        "  grads = gg(noise_mat, 0.0, np.random.rand(), 0.0)\n",
+        "  grads = grad(noise_mat, 0.0, np.random.rand(), 0.0)\n",
         "  noise_mat = noise_mat - 0.1 * grads\n",
         "plot_results(noise_mat, SIZE)"
       ],


### PR DESCRIPTION
Cool blog post!
The colab notebook should now run without issues with this minor edit.